### PR TITLE
Scatter plot helper refactor

### DIFF
--- a/API.gs
+++ b/API.gs
@@ -10,6 +10,10 @@ function clientSetConfiguration(config){
   SheetManager.updateChart(config);
 }
 
+function clientGetSpreadsheetID() {
+  return SheetManager.getID();
+}
+
 function clientGetVariables(){ 
   return SheetManager.getVariables(); 
 };
@@ -42,13 +46,17 @@ function clientGetCoordinates(latitude, longitude){
   return SheetManager.getCoordinates(latitude, longitude);
 };
 
-function clientGetValues(varname){
-  return SheetManager.getValues(varname);
+function clientGetValues(varName){
+  return SheetManager.getValues(varName);
 };
 
-function clientGetMultipleValues(varnameX, varnameY) {
-  return SheetManager.getMultipleValues(varnameX, varnameY);
+function clientGetMultipleValues(varNameX, varNameY) {
+  return SheetManager.getMultipleValues(varNameX, varNameY);
 }
+
+function clientQuery(varName1, varName2) {
+  return SheetManager.getQuery(varName1, varName2);
+} 
 
 function clientAddFormSubmission(institution, institutionAddress, location, locationAddress){
   return SheetManager.addFormSubmission(institution, institutionAddress, location, locationAddress);
@@ -56,4 +64,8 @@ function clientAddFormSubmission(institution, institutionAddress, location, loca
 
 function clientAddChart(config, type) {
   return SheetManager.addChart(config, type);
+}
+
+function clientAddStats(data) {
+  return SheetManager.addStats(data);
 }

--- a/API.gs
+++ b/API.gs
@@ -46,6 +46,14 @@ function clientGetValues(varname){
   return SheetManager.getValues(varname);
 };
 
+function clientGetMultipleValues(varnameX, varnameY) {
+  return SheetManager.getMultipleValues(varnameX, varnameY);
+}
+
 function clientAddFormSubmission(institution, institutionAddress, location, locationAddress){
   return SheetManager.addFormSubmission(institution, institutionAddress, location, locationAddress);
 };
+
+function clientAddChart(config, type) {
+  return SheetManager.addChart(config, type);
+}

--- a/ChartBuilder.gs
+++ b/ChartBuilder.gs
@@ -1,0 +1,44 @@
+var ChartBuilder = (function() {
+  var determineOffset = function() {
+    var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Charts');
+    var charts = sheet.getCharts();
+    if (charts.length > 0) {
+      return charts[charts.length - 1].getContainerInfo().getAnchorRow() + 1;
+    } else {
+      return 0;
+    }
+  }
+  
+  var addScatterChart = function(xRange, yRange, config) {
+    var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Charts');
+    var offset = determineOffset();
+    
+    var chart = sheet.newChart().asScatterChart();
+    chart.setTitle([config.y.variable, 'vs', config.x.variable].join(' '))
+      .setYAxisTitle(config.y.variable)
+      .setXAxisTitle(config.x.variable)
+      .addRange(xRange)
+      .addRange(yRange)
+      .setOption('aggregationTarget', 'category')
+      .setOption('pointSize', 1)
+      .setOption('legend.position', 'none')
+      .setPosition(3, 2, 0 , offset);
+      
+    if(config.x.axes.invert){ chart.setOption('hAxis.direction', -1); }
+    if(config.x.axes.log){ chart.setOption('hAxis.logScale', true); }
+    if(config.y.axes.invert){ chart.setOption('vAxis.direction', -1); }
+    if(config.y.axes.log){ chart.setOption('vAxis.logScale', true); }
+
+    if(config.x.range && config.x.range.min){ chart.setOption('hAxis.minValue',config.x.range.min); }
+    if(config.x.range && config.x.range.max){ chart.setOption('hAxis.maxValue',config.x.range.max); }
+    if(config.y.range && config.y.range.min){ chart.setOption('vAxis.minValue',config.y.range.min); }
+    if(config.y.range && config.y.range.max){ chart.setOption('vAxis.maxValue',config.y.range.max); }
+    
+    chart = chart.build();
+    sheet.insertChart(chart);
+  }
+  
+  return {
+    addScatterChart: addScatterChart
+  };
+})();

--- a/ChartBuilder.gs
+++ b/ChartBuilder.gs
@@ -3,7 +3,7 @@ var ChartBuilder = (function() {
     var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Charts');
     var charts = sheet.getCharts();
     if (charts.length > 0) {
-      return charts[charts.length - 1].getContainerInfo().getAnchorRow() + 1;
+      return charts[charts.length - 1].getContainerInfo().getAnchorRow() + 10;
     } else {
       return 0;
     }
@@ -12,7 +12,6 @@ var ChartBuilder = (function() {
   var addScatterChart = function(xRange, yRange, config) {
     var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Charts');
     var offset = determineOffset();
-    
     var chart = sheet.newChart().asScatterChart();
     chart.setTitle([config.y.variable, 'vs', config.x.variable].join(' '))
       .setYAxisTitle(config.y.variable)
@@ -33,6 +32,16 @@ var ChartBuilder = (function() {
     if(config.x.range && config.x.range.max){ chart.setOption('hAxis.maxValue',config.x.range.max); }
     if(config.y.range && config.y.range.min){ chart.setOption('vAxis.minValue',config.y.range.min); }
     if(config.y.range && config.y.range.max){ chart.setOption('vAxis.maxValue',config.y.range.max); }
+    if(config.trendlines){ 
+      var options = {
+        0: {
+          type: config.trendlines,
+          lineWidth: 3,
+          opacity: 0.3
+        }
+      };
+      chart.setOption('trendlines', options);
+    } 
     
     chart = chart.build();
     sheet.insertChart(chart);

--- a/SheetManager.gs
+++ b/SheetManager.gs
@@ -84,7 +84,7 @@ var SheetManager = (function(sheet){
     return augmented;
   }
   
-  var setupNamedSheet = function(sheetName) {
+  var setupNamedSheet = function(sheetName, callback) {
     var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(sheetName);
     
     if (sheet === undefined || sheet === null) {
@@ -92,8 +92,8 @@ var SheetManager = (function(sheet){
     } else {
       SpreadsheetApp.setActiveSheet(sheet);
     }
-    
-    return sheet;
+
+    callback();
   }
   
   var addChart = function(config, type) {
@@ -120,10 +120,12 @@ var SheetManager = (function(sheet){
   }
   
   var addStats = function(data) {
-    var sheet = setupNamedSheet('Statistics');
-    var rowToStart = sheet.getLastRow();
+    setupNamedSheet('Statistics', function() {
+      var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Statistics');
+      var rowToStart = sheet.getLastRow();
 
-    sheet.getRange(rowToStart + 1, 1, 4, 2).setValues(data);
+      sheet.getRange(rowToStart + 1, 1, 4, 2).setValues(data);                                      
+    });
   }
         
   var getCoordinates = function(latitude, longitude){

--- a/UIManager.gs
+++ b/UIManager.gs
@@ -4,9 +4,7 @@ var UIManager = (function(){
       var ui = SpreadsheetApp.getUi();
       ui.createMenu('Zoo Tools')
           .addItem('Scatter Plot Helper', 'clientShowScatter')
-          .addItem('Bar Chart Helper', 'clientShowSidebar')
-          .addItem('Histogram Helper', 'clientShowSidebar')
-          .addItem('Summary Stats Helper', 'clientShowSidebar')
+          .addItem('Summary Stats Helper', 'clientShowStats')
           .addSubMenu(ui.createMenu('Map')
             .addItem('Map Helper', 'clientShowMapDialog')
             .addItem('Student Location Survey', 'clientShowFormDialog'))

--- a/UIManager.gs
+++ b/UIManager.gs
@@ -3,7 +3,7 @@ var UIManager = (function(){
     registerMenu: function(){
       var ui = SpreadsheetApp.getUi();
       ui.createMenu('Zoo Tools')
-          .addItem('Scatter Plot Helper', 'clientShowScatterSidebar')
+          .addItem('Scatter Plot Helper', 'clientShowScatter')
           .addItem('Bar Chart Helper', 'clientShowSidebar')
           .addItem('Histogram Helper', 'clientShowSidebar')
           .addItem('Summary Stats Helper', 'clientShowSidebar')

--- a/form-dialog.html
+++ b/form-dialog.html
@@ -24,8 +24,8 @@
         placeholder="Enter a city name and state or country or a full address" onFocus="geolocate(event)">
       </div>
       <div class="block dialog-button-bar">
-          <button class="action" id="form-submit">Submit</button>
-          <button id="dialog-cancel-button" onclick="google.script.host.close()">Cancel</button>
+          <button class="button action" id="form-submit">Submit</button>
+          <button id="dialog-cancel-button" class="button" onclick="google.script.host.close()">Cancel</button>
       </div>
     </div>
 

--- a/map-dialog.html
+++ b/map-dialog.html
@@ -30,8 +30,8 @@
         <div id="map-container" style="height: 265px; width: 100%;"></div>
       </div>
       <div class="block dialog-button-bar">
-        <button type="button" onclick="getCoordinates()">Map</button>
-        <button type="button" onclick="google.script.host.close()">Close</button>
+        <button type="button" class="button action" onclick="getCoordinates()">Map</button>
+        <button type="button" class="button" onclick="google.script.host.close()">Close</button>
       </div> 
     </div>
 

--- a/scatter-script.html
+++ b/scatter-script.html
@@ -2,12 +2,25 @@
 // Setup and utility functions
 var columnDefs;
 var config = null;
-var store = null;
 var chart = null;
 var $ = function(sel){ return document.querySelector(sel); };
 var clean = function(node){ return !!node.value ? parseFloat(node.value) : null; };
-var enable = function(node){ node.removeAttribute('disabled'); }
-var disable = function(node){ node.setAttribute('disabled', true); }
+var enable = function(node){ node.removeAttribute('disabled'); };
+var disable = function(node){ node.setAttribute('disabled', true); };
+
+function showStatus(msg, classId) {
+  var status = $('#status'); 
+  status.className = ""
+  status.innerHTML = msg;
+  if (classId) {
+    status.classList.add(classId);
+  }
+}
+
+function failureHandler(err) {
+  console.error(err);
+  showStatus('Something went wrong: ' + err, 'error');
+}
 
 // Load the Google Visualization library
 google.load("visualization", "1", {packages:["corechart"]});
@@ -17,24 +30,51 @@ google.setOnLoadCallback(loadChart);
 function loadChart() {
   chart = new google.visualization.ScatterChart($('#chart-preview'));
 } 
+
 // use async call to determine initial state of dropdown lists
 // from contents of chart cells
-google.script.run.withSuccessHandler(function(res){
-  console.log('res', res);
-  var refs = {};
-  for(var idx in res){
-    // Handle if user is not on a sheet with data! Response returns empty string for names
-    if (res.length === 1) {
-      showStatus('No variables to choose from. Close and reopen helper on sheet with data.');
-    }
- 
-    refs[res[idx].name] = res[idx];
+function getVariables() {
+  showStatus('Getting variables...');
+  google.script.run
+    .withSuccessHandler(function(res){
+      var refs = {};
+      for(var idx in res) {
+        refs[res[idx].name] = res[idx];
+      }
+      columnDefs = refs;
+    
+      // Handle if user is not on a sheet with no data
+      if (res.length === 0) {
+        showStatus('No variables to choose from.');
+      }
+      
+      if (res !== columnDefs) {
+        addVariableOptions()
+      }
+      enable($('#xVar'));
+      enable($('#yVar'));
+      enable($('#updateBtn'));
+      showStatus('');
+    })
+    .withFailureHandler(failureHandler)
+    .clientGetVariables();
+}
+
+getVariables();
+
+function addVariableOptions() {
+  var options = '';
+  var selects = document.querySelectorAll('select[data-select="variable"]');
+  
+  for (var key in columnDefs) {
+    var newOption = '<option>' + columnDefs[key].name + '</option>';
+    options += newOption;
   }
-  columnDefs = refs;
-  enable($('#xVar'));
-  enable($('#yVar'));
-  enable($('#updateBtn'));
-}).clientGetVariables();
+  
+  for (var i = 0; i < selects.length; i++) {
+    selects[i].innerHTML = options;
+  }
+}
 
 function applyState(config){
   disable($('#xMin')); disable($('#xMax'));
@@ -47,6 +87,7 @@ function applyState(config){
   $('#yVar').value = config.y.variable;
   $('#invertY').checked = config.y.axes.invert;
   $('#logY').checked = config.y.axes.log;
+  $('#trendlineSelector').value = config.trendlines;
   
   if(config.x.range){
     $('#xScaleSpecific').checked = true;
@@ -82,7 +123,8 @@ function extractState(){
       variable: $('#yVar').value,
       axes: { invert: $('#invertY').checked, log: $('#logY').checked },
       range: $('#yScaleDefault').checked ? null : { min: clean($('#yMin')), max: clean($('#yMax')) }
-    }
+    },
+    trendlines: $('#trendlineSelector').value
   };
 
   return res;
@@ -92,7 +134,7 @@ function extractState(){
 // able to submit (plotting X vs. X just makes no sense)
 function updateSelection(src){
     var state = extractState();
-    if(src){
+    if (src) {
       var target = state[src];
       var defRow = columnDefs[target.variable];
       target.axes.invert = defRow.invert;
@@ -102,8 +144,15 @@ function updateSelection(src){
         target.range = { min: defRow.min, max: defRow.max };
       }
     }
+
     applyState(state);
-  updateBtn.removeAttribute('disabled');
+    updateBtn.removeAttribute('disabled');
+}
+
+function toggleVar(varName){
+  var elemId = varName + 'Def';
+    
+  document.getElementById(elemId).classList.toggle('collapse');
 }
 
 // update the chart from the client's selected variables
@@ -151,7 +200,8 @@ function buildChartOptions(state) {
   if (state.x.axes.log === true) { options.hAxis.logScale = true; }
   if (state.y.axes.invert === true) { options.vAxis.direction = -1; }
   if (state.y.axes.log === true) { options.vAxis.logScale = true; }
-  
+  if (state.trendlines !== "none") { options.trendlines = state.trendlines; }
+
   return options;
 }
 
@@ -161,7 +211,7 @@ function previewChart(spreadsheetValues) {
   var data = google.visualization.arrayToDataTable(load);
   var options = buildChartOptions(state);
   var sendToSheetBtn = $('#sendToSheetBtn');
-  
+
   disable(sendToSheetBtn);
   
   // Add event listener
@@ -173,7 +223,7 @@ function previewChart(spreadsheetValues) {
   chart.draw(data, options);
 }
 
-function sendToSheet() {
+function clientSendToSheet() {
   var state = extractState();
   showStatus('Sending...');
   google.script.run
@@ -182,28 +232,6 @@ function sendToSheet() {
     })
     .withFailureHandler(failureHandler)
     .clientAddChart(state, 'scatter');
-}
-
-var expand = { x: false, y: false };
-
-function toggleVar(varName){
-  var elemId = varName + 'Def';
-    
-    document.getElementById(elemId).classList.toggle('collapse');
-}
-
-function showStatus(msg, classId) {
-  var status = $('#status'); 
-  status.className = ""
-  status.innerHTML = msg;
-  if (classId) {
-    status.classList.add(classId);
-  }
-}
-
-function failureHandler(err) {
-  console.error(err);
-  showStatus('Something went wrong: ' + err, 'error');
 }
 
 </script>

--- a/scatter-script.html
+++ b/scatter-script.html
@@ -1,29 +1,40 @@
 <script type="text/javascript">
-
+// Setup and utility functions
 var columnDefs;
 var config = null;
-
-// use async call to determine initial state of dropdown lists
-// from contents of chart cells
-google.script.run.withSuccessHandler(function(res){
-    config = res;
-    applyState(config);
-	document.getElementById('xVar').removeAttribute('disabled');
-	document.getElementById('yVar').removeAttribute('disabled');
-}).clientGetConfiguration();
-
-google.script.run.withSuccessHandler(function(res){
-	var refs = {};
-	for(var idx in res){
-		refs[res[idx].name] = res[idx];
-	}
-	columnDefs = refs;
-}).clientGetVariables();
-
+var store = null;
+var chart = null;
 var $ = function(sel){ return document.querySelector(sel); };
 var clean = function(node){ return !!node.value ? parseFloat(node.value) : null; };
 var enable = function(node){ node.removeAttribute('disabled'); }
 var disable = function(node){ node.setAttribute('disabled', true); }
+
+// Load the Google Visualization library
+google.load("visualization", "1", {packages:["corechart"]});
+google.setOnLoadCallback(loadChart);
+
+// Instantiate the chart
+function loadChart() {
+  chart = new google.visualization.ScatterChart($('#chart-preview'));
+} 
+// use async call to determine initial state of dropdown lists
+// from contents of chart cells
+google.script.run.withSuccessHandler(function(res){
+  console.log('res', res);
+  var refs = {};
+  for(var idx in res){
+    // Handle if user is not on a sheet with data! Response returns empty string for names
+    if (res.length === 1) {
+      showStatus('No variables to choose from. Close and reopen helper on sheet with data.');
+    }
+ 
+    refs[res[idx].name] = res[idx];
+  }
+  columnDefs = refs;
+  enable($('#xVar'));
+  enable($('#yVar'));
+  enable($('#updateBtn'));
+}).clientGetVariables();
 
 function applyState(config){
   disable($('#xMin')); disable($('#xMax'));
@@ -32,11 +43,11 @@ function applyState(config){
   $('#xVar').value = config.x.variable;
   $('#invertX').checked = config.x.axes.invert;
   $('#logX').checked = config.x.axes.log;
-
+  
   $('#yVar').value = config.y.variable;
   $('#invertY').checked = config.y.axes.invert;
   $('#logY').checked = config.y.axes.log;
-
+  
   if(config.x.range){
     $('#xScaleSpecific').checked = true;
     enable($('#xMin')); enable($('#xMax'));
@@ -47,7 +58,7 @@ function applyState(config){
     $('#xMin').value = null;
     $('#xMax').value = null;
   }
-
+  
   if(config.y.range){
     $('#yScaleSpecific').checked = true;
     enable($('#yMin')); enable($('#yMax'));
@@ -92,28 +103,107 @@ function updateSelection(src){
       }
     }
     applyState(state);
-	updateBtn.removeAttribute('disabled');
+  updateBtn.removeAttribute('disabled');
 }
 
 // update the chart from the client's selected variables
 function clientChangeSelection(){
-    google.script.run.clientSetConfiguration(extractState());
+    var xVar = $('#xVar').value;
+    var yVar = $('#yVar').value;
+    
+    showStatus('Drawing Plot...');
+    
+    google.script.run
+      .withSuccessHandler(function(res) {
+        showStatus('');
+        previewChart(res);
+      })
+      .withFailureHandler(failureHandler)
+      .clientGetMultipleValues(xVar, yVar);
 }
 
-function removeClass(e,c) {e.className = e.className.replace( new RegExp('(?:^|\\s)'+c+'(?!\\S)') ,''); }
-function addClass(e,c){ e.className = [e.className, c].join(' '); }
+// Use response from sheet to setup data in format expected by Charts API for scatter plots
+function setupDataTable(spreadsheetValues) {
+  var state = extractState();
+  var table = [[state.x.variable, state.y.variable]];
+  for (var i = spreadsheetValues.x.length - 1; i >= 0; i--) {
+    var row = [spreadsheetValues.x[i], spreadsheetValues.y[i]];
+    table.push(row);
+  };
+  
+  return table;
+}
+
+function buildChartOptions(state) {
+  options = {
+    hAxis: { title: state.x.variable },
+    vAxis: { title: state.y.variable },
+    pointSize: 1,
+    aggregationTarget: 'category',
+    legend: { position: 'none' }
+  }
+  
+  if (state.x.range && state.x.range.min) { options.hAxis.minValue = state.x.range.min; } 
+  if (state.x.range && state.x.range.max) { options.hAxis.maxValue = state.x.range.max; }
+  if (state.y.range && state.y.range.min) { options.vAxis.minValue = state.y.range.min; }
+  if (state.y.range && state.y.range.max) { options.vAxis.maxValue = state.y.range.max; }
+  if (state.x.axes.invert === true) { options.hAxis.direction = -1; }
+  if (state.x.axes.log === true) { options.hAxis.logScale = true; }
+  if (state.y.axes.invert === true) { options.vAxis.direction = -1; }
+  if (state.y.axes.log === true) { options.vAxis.logScale = true; }
+  
+  return options;
+}
+
+function previewChart(spreadsheetValues) {
+  var load = setupDataTable(spreadsheetValues);
+  var state = extractState();
+  var data = google.visualization.arrayToDataTable(load);
+  var options = buildChartOptions(state);
+  var sendToSheetBtn = $('#sendToSheetBtn');
+  
+  disable(sendToSheetBtn);
+  
+  // Add event listener
+  google.visualization.events.addListener(chart, 'ready', function(){
+    enable(sendToSheetBtn);
+  });
+  
+  // Draw the chart
+  chart.draw(data, options);
+}
+
+function sendToSheet() {
+  var state = extractState();
+  showStatus('Sending...');
+  google.script.run
+    .withSuccessHandler(function(res){
+      showStatus('');
+    })
+    .withFailureHandler(failureHandler)
+    .clientAddChart(state, 'scatter');
+}
 
 var expand = { x: false, y: false };
 
 function toggleVar(varName){
-	var elemId = varName + 'Def';
+  var elemId = varName + 'Def';
+    
+    document.getElementById(elemId).classList.toggle('collapse');
+}
 
-	removeClass(document.getElementById(elemId), 'collapse');
-	if(expand[varName]){
-		addClass(document.getElementById(elemId), 'collapse');
-	}
+function showStatus(msg, classId) {
+  var status = $('#status'); 
+  status.className = ""
+  status.innerHTML = msg;
+  if (classId) {
+    status.classList.add(classId);
+  }
+}
 
-	expand[varName] = !expand[varName];
+function failureHandler(err) {
+  console.error(err);
+  showStatus('Something went wrong: ' + err, 'error');
 }
 
 </script>

--- a/scatter.html
+++ b/scatter.html
@@ -10,14 +10,15 @@
       <h1>Scatter Plot Helper</h1>
     </div>
     <div class="block">
-      You may change the independent (X) and dependent (Y) variables below, then press Plot to draw or redraw the plot.
+      <p>You may change the independent (X) and dependent (Y) variables below, then press Plot to draw or redraw the plot.</p>
+      <button class="button green" onclick="getVariables()">Refresh</button>
     </div>
     <div class="block">
       <? columnDefs = clientGetVariables(); ?>
       <fieldset>
       <legend>X Variable</legend>
       <div class="block form-group collapse" id="xDef">
-        <select id="xVar" style="width: 100%;" oninput="updateSelection('x')" disabled>
+        <select id="xVar" data-select="variable" style="width: 100%;" oninput="updateSelection('x')" disabled>
           <? for(var i = 0; i < columnDefs.length; i++) { ?>
             <option><?= columnDefs[i].name ?></option>
           <? } ?>
@@ -46,7 +47,7 @@
       <fieldset>
       <legend>Y Variable</legend>
       <div class="block form-group collapse" id="yDef">
-        <select id="yVar" style="width: 100%;" oninput="updateSelection('y')" disabled>
+        <select id="yVar" data-select="variable" style="width: 100%;" oninput="updateSelection('y')" disabled>
           <? for(var i = 0; i < columnDefs.length; i++) { ?>
             <option><?= columnDefs[i].name ?></option>
           <? } ?>
@@ -73,11 +74,20 @@
       </div>
       </fieldset>
     </div>
+    <div class="trendline-option-container">
+      <label for="trendlineSelector">Trendline</label>
+      <select id="trendlineSelector" name="trendline" onclick="updateSelection('trendlines')">
+        <option value="none" selected>None</option>
+        <option value="linear">Linear</option>
+        <option value="exponential">Exponential</option>
+        <option value="polynomial">Polynomial</option>
+      </select>
+    </div>
     <div id="chart-preview" style="width: 100%"></div>
     <div class="action-button-bar" style="text-align: center; ">
       <div id="status" style="display: block; margin: 1em;"></div>
       <button type="button" id="updateBtn" class="button action" onclick="clientChangeSelection()" disabled>Plot</button>
-      <button type="button" id="sendToSheetBtn" class="button create" onclick="sendToSheet()" disabled>Send to Sheet</button>
+      <button type="button" id="sendToSheetBtn" class="button create" onclick="clientSendToSheet()" disabled>Send to Sheet</button>
       <button type="button" class="button" onclick="google.script.host.close()">Close</button>
     </div>
     <script type="text/javascript" src="https://www.google.com/jsapi"></script>

--- a/scatter.html
+++ b/scatter.html
@@ -10,7 +10,7 @@
       <h1>Scatter Plot Helper</h1>
     </div>
     <div class="block">
-      You may change the independent (X) and dependent (Y) variables below, then press Update to redraw the plot.
+      You may change the independent (X) and dependent (Y) variables below, then press Plot to draw or redraw the plot.
     </div>
     <div class="block">
       <? columnDefs = clientGetVariables(); ?>
@@ -23,20 +23,24 @@
           <? } ?>
         </select>
         <div class="extended">
-          <p><strong>Axis</strong></p>
-          <div style="float: right; width: 50%;"><input type="checkbox" id="logX" onclick="updateSelection()"><label for="logX">Logarithmic</label></div>
-          <div><input type="checkbox" id="invertX" onclick="updateSelection()"/><label for="invertX">Invert</label></div>
-        </div>
-        <div class="extended" id="xRange">
-          <p><strong>Range</strong></p>
-          <p><input type="radio" id="xScaleDefault" name="xScale" onclick="updateSelection()" checked><label for="xScaleDefault">Auto</label></p>
-          <p><input type="radio" id="xScaleSpecific" name="xScale" onclick="updateSelection()"><label for="xScaleSpecific">Specified</label></p>
-          <div style="text-indent: 1.5em;">
-            <div style="text-align: justify"><input type="text" pattern="\d*" id="xMin" style="width: 30%; " disabled/>&nbsp; to &nbsp;<input type="text" pattern="\d*" id="xMax" style="width: 30%; " disabled /></div>
+          <div>
+            <p><strong>Axis</strong></p>
+            <div style="float: right; width: 50%;"><input type="checkbox" id="logX" onclick="updateSelection()"><label for="logX">Logarithmic</label></div>
+            <div><input type="checkbox" id="invertX" onclick="updateSelection()"/><label for="invertX">Invert</label></div>
+          </div>
+          <div id="xRange">
+            <p><strong>Range</strong></p>
+            <p><input type="radio" id="xScaleDefault" name="xScale" onclick="updateSelection()" checked><label for="xScaleDefault">Auto</label></p>
+            <p><input type="radio" id="xScaleSpecific" name="xScale" onclick="updateSelection()"><label for="xScaleSpecific">Specified</label></p>
+            <div style="text-indent: 1.5em;">
+              <div style="text-align: justify"><input type="text" pattern="\d*" id="xMin" style="width: 30%; " disabled/>&nbsp; to &nbsp;<input type="text" pattern="\d*" id="xMax" style="width: 30%; " disabled /></div>
+            </div>
           </div>
         </div>
-        <a href="javascript:void(0);"><span class="toggle toggle-more" onclick="toggleVar('x')">More &#9662;</span></a>
-        <a href="javascript:void(0);"><span class="toggle toggle-less" onclick="toggleVar('x')">Less &#9652;</span></a>
+        <div class="toggle-buttons">
+          <button type="button" class="toggle toggle-more" onclick="toggleVar('x')">More &#9662;</button>
+          <button type="button" class="toggle toggle-less" onclick="toggleVar('x')">Less &#9652;</button>
+        </div>
       </div>
       </fieldset>
       <fieldset>
@@ -48,28 +52,35 @@
           <? } ?>
         </select>
         <div class="extended">
-          <p><strong>Axis</strong></p>
-          <div style="float: right; width: 50%;"><input type="checkbox" id="logY" onclick="updateSelection()"><label for="logY">Logarithmic</label></div>
-          <div><input type="checkbox" id="invertY" onclick="updateSelection()"/><label for="invertY">Invert</label></div>
-        </div>
-        <div class="extended" id="xRange">
-          <p><strong>Range</strong></p>
-          <p><input type="radio" id="yScaleDefault" name="yScale" onclick="updateSelection()" checked><label for="yScaleDefault">Auto</label></p>
-          <p><input type="radio" id="yScaleSpecific" name="yScale" onclick="updateSelection()"><label for="yScaleSpecific">Specified</label></p>
-          <div style="text-indent: 1.5em;">
-            <div style="text-align: justify"><input type="text" pattern="\d*" id="yMin" style="width: 30%; " disabled/>&nbsp; to &nbsp;<input type="text" pattern="\d*" id="yMax" style="width: 30%; " disabled /></div>
+          <div>
+            <p><strong>Axis</strong></p>
+            <div style="float: right; width: 50%;"><input type="checkbox" id="logY" onclick="updateSelection()"><label for="logY">Logarithmic</label></div>
+            <div><input type="checkbox" id="invertY" onclick="updateSelection()"/><label for="invertY">Invert</label></div>
+          </div>
+          <div id="xRange">
+            <p><strong>Range</strong></p>
+            <p><input type="radio" id="yScaleDefault" name="yScale" onclick="updateSelection()" checked><label for="yScaleDefault">Auto</label></p>
+            <p><input type="radio" id="yScaleSpecific" name="yScale" onclick="updateSelection()"><label for="yScaleSpecific">Specified</label></p>
+            <div style="text-indent: 1.5em;">
+              <div style="text-align: justify"><input type="text" pattern="\d*" id="yMin" style="width: 30%; " disabled/>&nbsp; to &nbsp;<input type="text" pattern="\d*" id="yMax" style="width: 30%; " disabled /></div>
+            </div>
           </div>
         </div>
-        <a href="javascript:void(0);"><span class="toggle toggle-more" onclick="toggleVar('y')">More &#9662;</span></a>
-        <a href="javascript:void(0);"><span class="toggle toggle-less" onclick="toggleVar('y')">Less &#9652;</span></a>
+        <div class="toggle-buttons">
+          <button type="button" class="toggle toggle-more" onclick="toggleVar('y')">More &#9662;</button>
+          <button type="button" class="toggle toggle-less" onclick="toggleVar('y')">Less &#9652;</button>
+        </div>
       </div>
       </fieldset>
     </div>
-    <div class="block form-group" style="text-align: center; ">
-      <button id="updateBtn" class="action" onclick="clientChangeSelection()" disabled>Update</button>
-      <button onclick="google.script.host.close()">Close</button>
+    <div id="chart-preview" style="width: 100%"></div>
+    <div class="action-button-bar" style="text-align: center; ">
+      <div id="status" style="display: block; margin: 1em;"></div>
+      <button type="button" id="updateBtn" class="button action" onclick="clientChangeSelection()" disabled>Plot</button>
+      <button type="button" id="sendToSheetBtn" class="button create" onclick="sendToSheet()" disabled>Send to Sheet</button>
+      <button type="button" class="button" onclick="google.script.host.close()">Close</button>
     </div>
-    
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
     <?!= include('scatter-script'); ?>
   </body>
 </html>

--- a/stats-script.html
+++ b/stats-script.html
@@ -68,24 +68,26 @@ function addVariableOptions() {
 
 function calculateNew(){
 	var varName = $('#varName').value;
-    var resultsList = $('#resultList');
+  var resultsList = $('#resultList');
+  showStatus('Calculating...');
 	google.script.run
-      .withSuccessHandler(function(res){
-		summary = {
-			name: varName,
-			min: math.round(math.min(res),3),
-			max: math.round(math.max(res),3),
-			mean: math.round(math.mean(res),3),
-			stdev: math.round(math.std(res),3)
-		}
+    .withSuccessHandler(function(res){
+		  summary = {
+			  name: varName,
+			  min: math.round(math.min(res),3),
+			  max: math.round(math.max(res),3),
+			  mean: math.round(math.mean(res),3),
+			  stdev: math.round(math.std(res),3)
+		  }
 
-		resultsList.innerHTML = statTemplate(summary);
-        resultsList.classList.remove('hide');
-        resultsList.classList.add('show');
-        enable($('#addToSheetBtn'));
+		  resultsList.innerHTML = statTemplate(summary);
+      resultsList.classList.remove('hide');
+      resultsList.classList.add('show');
+      enable($('#addToSheetBtn'));
+      showStatus('');
 	  })
-      .withFailureHandler(failureHandler)
-      .clientGetValues(varName);
+    .withFailureHandler(failureHandler)
+    .clientGetValues(varName);
 }
 
 var compile = function(selector){

--- a/stats-script.html
+++ b/stats-script.html
@@ -4,20 +4,88 @@
 var columnDefs = null;
 var template = null;
 var statTemplate = null;
+var summary = null;
+var $ = function(sel){ return document.querySelector(sel); };
+var enable = function(node){ node.removeAttribute('disabled'); }
+var disable = function(node){ node.setAttribute('disabled', true); }
+
+function showStatus(msg, classId) {
+  var status = $('#status'); 
+  status.className = ""
+  status.innerHTML = msg;
+  if (classId) {
+    status.classList.add(classId);
+  }
+}
+
+function failureHandler(err) {
+  console.error(err);
+  showStatus('Something went wrong: ' + err, 'error');
+}
+
+// use async call to determine initial state of dropdown lists
+// from contents of chart cells
+function getVariables() {
+  showStatus('Getting variables...');
+  google.script.run
+    .withSuccessHandler(function(res){
+      var refs = {};
+      for(var idx in res){
+        refs[res[idx].name] = res[idx];
+      }
+      columnDefs = refs;
+    
+      // Handle if user is not on a sheet with no data
+      if (res.length == 0) {
+        showStatus('No variables to choose from.');
+      }
+      
+      if (res != columnDefs) {
+        addVariableOptions()
+      }
+      showStatus('');
+      enable($('#calcBtn'));
+    })
+    .withFailureHandler(failureHandler)
+    .clientGetVariables();
+}
+
+getVariables();
+
+function addVariableOptions() {
+  var options = '';
+  var selects = document.querySelectorAll('select');
+  
+  for (var key in columnDefs) {
+    var newOption = '<option>' + columnDefs[key].name + '</option>';
+    options += newOption;
+  }
+  
+  for (var i = 0; i < selects.length; i++) {
+    selects[i].innerHTML = options;
+  }
+}
 
 function calculateNew(){
-	var varName = document.querySelector('#varName').value;
-	google.script.run.withSuccessHandler(function(res){
-		var summary = {
+	var varName = $('#varName').value;
+    var resultsList = $('#resultList');
+	google.script.run
+      .withSuccessHandler(function(res){
+		summary = {
 			name: varName,
-			min: math.round(math.min(res),7),
-			max: math.round(math.max(res),7),
-			mean: math.round(math.mean(res),7),
-			stdev: math.round(math.std(res),7)
+			min: math.round(math.min(res),3),
+			max: math.round(math.max(res),3),
+			mean: math.round(math.mean(res),3),
+			stdev: math.round(math.std(res),3)
 		}
 
-		document.querySelector('#resultList').innerHTML += statTemplate(summary);
-	}).clientGetValues(varName);
+		resultsList.innerHTML = statTemplate(summary);
+        resultsList.classList.remove('hide');
+        resultsList.classList.add('show');
+        enable($('#addToSheetBtn'));
+	  })
+      .withFailureHandler(failureHandler)
+      .clientGetValues(varName);
 }
 
 var compile = function(selector){
@@ -50,7 +118,22 @@ var compile = function(selector){
 };
 
 var statTemplate = compile('#result');
-document.querySelector('#resultList').className = '';
+
+function clientAddToSheet() {
+  var dataTable = [
+    [summary.name + " Min", summary.min],
+    [summary.name + " Max", summary.max],
+    [summary.name + " Mean", summary.mean],
+    [summary.name + " Std. Dev.", summary.stdev]
+  ];
+  showStatus('Sending...');
+  
+  google.script.run
+    .withSuccessHandler(function() {
+      showStatus('');
+    })
+    .withFailureHandler(failureHandler)
+    .clientAddStats(dataTable);
+}
 
 </script>
-

--- a/stats.html
+++ b/stats.html
@@ -12,51 +12,53 @@
     <div class="block form-group">
       <p>Calculate summary statistics for selected variables.</p>
     </div>
-    <div class="preinit" id="resultList">
+    <div class="preinit" id="resultList" class="hide">
 
-    <div class="block form-group item result">
-        <table style="margin-left: 0.2em; width: 100%;">
+    <div class="block form-group" id="result">
+        <table class="stats-table" style="margin-left: 0.2em; width: 100%;" summary="The minimum, maximum, mean, and standard deviation (row headings) of the selected variable.">
           <colgroup>
-            <col style="width: 45%;" />
-            <col style="width: 55%;" />
+            <col style="width: 25%;" />
+            <col style="width: 75%;" />
           </colgroup>
+          <caption><strong>{{name}}</strong></caption>
           <tbody>
             <tr>
-              <td><strong>{{name}} Min</strong></td>
+              <th scope="row"><strong>Min</strong></th>
               <td> {{min}}</td>
             </tr>
             <tr>
-              <td><strong>{{name}} Max</strong></td>
+              <th scope="row"><strong>Max</strong></th>
               <td> {{max}}</td>
             </tr>
             <tr>
-              <td><strong>{{name}} Mean</strong></td>
+              <th scope="row"><strong>Mean</strong></th>
               <td> {{mean}} </td>
             </tr>
             <tr>
-              <td><strong>{{name}} Std. Dev.</strong></td>
+              <th scope="row"><strong>Std. Dev.</strong></th>
               <td> {{stdev}} </td>
             </tr>
           </tbody>
         </table>
     </div>
-
     </div>
     
     <p />
     <? columnDefs = clientGetVariables(); ?>
     <div class="block form-group">
-    <select id="varName" style="width: 100%;" >
-    <? for(var i = 0; i < columnDefs.length; i++) { ?>
-    <option><?= columnDefs[i].name ?></option>
-    <? } ?>
-    </select>
+      <select id="varName" style="width: 70%;" >
+        <? for(var i = 0; i < columnDefs.length; i++) { ?>
+        <option><?= columnDefs[i].name ?></option>
+        <? } ?>
+      </select>
+      <button class="button green" onclick="getVariables()">Refresh</button>
     </div> 
     <div class="block form-group" style="text-align: center; ">
-      <button id="calcBtn" class="action" onclick="calculateNew()">Calculate</button>
-      <button onclick="google.script.host.close()">Close</button>
+      <div id="status" style="display: block; margin: 1em;"></div>
+      <button id="calcBtn" class="button action" onclick="calculateNew()" disabled>Calculate</button>
+      <button id="addToSheetBtn" class="button create" onclick="clientAddToSheet()" disabled>Add to Sheet</button>
+      <button class="button" onclick="google.script.host.close()">Close</button>
     </div>      
     <?!= include('stats-script'); ?>
   </body>
 </html>
-

--- a/styles.html
+++ b/styles.html
@@ -12,6 +12,13 @@
     text-decoration: none
   }
   
+  .button.create {
+    padding: 0 0.25em;
+  }
+  
+  .show { display: block; } 
+  .hide { display: none; }
+  
   fieldset{ margin-bottom: 2em; } 
   legend{ margin-left: -0.4em; }
   
@@ -83,5 +90,13 @@
   
   .dialog .dialog-button-bar {
     margin: 10px 0;
+  }
+  
+  .stats-table td {
+    text-align: center;
+  }
+  
+  .stats-table th {
+    padding: 0.5em 0;
   }
 </style>

--- a/styles.html
+++ b/styles.html
@@ -55,7 +55,11 @@
     margin: 0;
   }
   
-  .dialog h6, .dialog .form-group {
+ .dialog h6 {
+    margin: 0 0 0.5em 0;
+  }
+
+  .dialog .form-group {
     margin: 0.5em 0;
   }
   
@@ -78,6 +82,6 @@
   }
   
   .dialog .dialog-button-bar {
-    margin-bottom: 10px;
+    margin: 10px 0;
   }
 </style>

--- a/styles.html
+++ b/styles.html
@@ -1,24 +1,61 @@
 <style type="text/css">
+  /* Button reset */
+  button, button:focus, button:hover {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    line-height: inherit;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    text-decoration: none
+  }
+  
   fieldset{ margin-bottom: 2em; } 
   legend{ margin-left: -0.4em; }
-  .collapse .extended{ display: none; }
-  .extended{ display: block; }
-  .toggle{ font-size: 0.9em; float: right; margin-top: 1em; cursor: pointer; }
+  
+  .collapse .extended { 
+    max-height: 0;
+  }
+    
+  .extended {  
+    max-height: 200px;
+    overflow-y: hidden;
+    transition: all .5s ease-in-out;
+    -webkit-transition: all .5s ease-in-out;
+  }
+  
+  .toggle-buttons {
+    float: right;
+    position: relative;
+    width: 100%;
+  } 
+  
+  .toggle, .toggle:hover, .toggle:focus { 
+    float: right;
+    font-size: 0.9em;  
+    margin-top: 1em; 
+    cursor: pointer; 
+  }
+  
   .toggle-more{ display: none; }
   .toggle-less{ }
-  .collapse .toggle-more{ display: block; }
-  .collapse .toggle-less{ display: none; }
+  
+  .collapse .toggle-more { 
+    display: block;
+  }
+  
+  .collapse .toggle-less { 
+    display: none; 
+  }
   .preinit fieldset{ display: none; }
   
   .dialog {
     margin: 0;
   }
   
-  .dialog h6 {
-    margin: 0 0 0.5em 0;
-  }
-
-  .dialog .form-group {
+  .dialog h6, .dialog .form-group {
     margin: 0.5em 0;
   }
   
@@ -41,6 +78,6 @@
   }
   
   .dialog .dialog-button-bar {
-    margin: 10px 0;
+    margin-bottom: 10px;
   }
 </style>


### PR DESCRIPTION
A partially done refactor, but functional. Part of the refactor is to make the scatter plot helper agnostic from the data it's plotting as well as add a skeleton for the other helpers that will be built out. I think this PR finishes #12 and I think partially addresses #13 which I don't think is possible or at least I didn't figure it out. Also setups up potentially a way to do #8 using the Charts API. An outline of changes:
- Made style changes and added a nice css animation for the `less` and `more` buttons. 
- A few markup changes to make it more accessible/screen reader friendly
- Added a bunch of client side logic to add a chart preview into the sidebar itself. 
  - Initially I was refactoring the chart drawing to use the [Google Visualization API/Charts API](https://developers.google.com/chart/interactive/docs/) and was going to strip out the logic from the Spreadsheet google apps script, however, I discovered that you cannot send a chart object from the client side to the spreadsheet. It caused a circular reference error ([see parameter description](https://developers.google.com/apps-script/guides/html/reference/run)). 
  - I was thinking ahead of when we would need to build the histogram helper since GAS doesn't directly support that in the `EmbeddedChart` class. But since I learned you can't send a chart from the client side, I'm still not sure what to do with this.
  - The Charts API is still useful I think for a preview of the chart so users can edit as needed before embedding it into the spreadsheet itself.
  - Charts API is super powerful and has lots of features we should explore later including the [query class for fetching data from sheets](https://developers.google.com/chart/interactive/docs/reference#queryobjects), [built in tools and dashboards](https://developers.google.com/chart/interactive/docs/gallery/controls) which we should look at for the future sidebar helpers, and probably other cool stuff.
- Added a `ChartBuilder` class to handle the actual chart type, options, and building it in the spreadsheet when you click `Send to Sheet`
- Stripped out the metadata stuff and the storing of chart info for editing. Again the thought is that the editing would happen with the preview in the sidebar. Also tracking metadata, presets, etc for all of the scatter plots made would make this a lot more complicated (but could be persuaded to add it back in).
- Charts are added into a specific sheet labeled as "Charts"
- Added a place to insert status messages into the UI and some error handling

Anyway, @amyrebecca could you review this since it's a big refactor on the stuff you did before? Thanks!
