### PR TITLE
Don't use the placeholder in the filter

### DIFF
--- a/filter-script.html
+++ b/filter-script.html
@@ -114,7 +114,8 @@ function getRange() {
 function getAllColumns(event) {
   var checked = $('#compareAllColumnsInput').checked;
   var columnHeaders = document.querySelectorAll('select[data-select="variable"]')[0];
-
+  var arrayColumnHeaders = Array.from(columnHeaders); // Make it a true array
+  arrayColumnHeaders.shift(); // Remove the placeholder
   if (checked) {
     for (var i = 0; i < columnHeaders.length; i++) {
       google.script.run


### PR DESCRIPTION
Fixing a bug introduced in the last version bump that included the dropdown menu placeholder in the filter query logic.